### PR TITLE
Adds important PsyLend state structs

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -5,7 +5,7 @@ seeds = false
 #psylend_cpi = "BVr85VrQhRJAixhUt68bmodrvzv5nQXdUMbuihRWqNGb"
 
 [programs.devnet]
-psylend_cpi = "BVr85VrQhRJAixhUt68bmodrvzv5nQXdUMbuihRWqNGb"
+psylend_cpi = "2BUrizpXHXA43qJxnzRBGpwemtHKVqB3JE3G63NKHbzz"
 psylend = { address = "8bpiM4yhcLYMSeCBTVFWisneXPQQWPYSA5ZpMm4DKAgT", idl = "./deps/psylend.json"}
 cpi_dummy = { address = "Ev6JrN5HqrKwXhoB9jucLdn51yzzDvWmBHkubXWavRio", idl = "./deps/cpi_dummy.json"}
 
@@ -20,7 +20,7 @@ cluster = "devnet"
 wallet = "/home/fish/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
-#test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/basic-integrator.ts"
+#test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/basic-integrator.ts"
 #test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/dummy-cpi.ts"
 #test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/psylend-cpi.ts"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab62d2fa33726dbe6321cc97ef96d8cde531e3eeaf858a058de53a8a6d40d8f"
+checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -967,11 +973,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "psy-math"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56afbe21ad6f27b515229cd233f8c8fe87147737e774c87fc1fe3ef4e0adfe32"
+dependencies = [
+ "bytemuck",
+ "static_assertions",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
 name = "psylend-cpi"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
+ "bytemuck",
+ "psy-math",
 ]
 
 [[package]]
@@ -1424,6 +1444,18 @@ name = "ucd-trie"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/programs/psylend-cpi/Cargo.toml
+++ b/programs/psylend-cpi/Cargo.toml
@@ -26,4 +26,6 @@ overflow-checks = true
 [dependencies]
 anchor-lang = "0.24.2"
 anchor-spl = { version = "0.24.2", features = ["dex"] }
+bytemuck = { version = "1.7", features = ["derive"] }
+psy-math = "1.0.0"
 

--- a/programs/psylend-cpi/src/combinations/get_current_interest.rs
+++ b/programs/psylend-cpi/src/combinations/get_current_interest.rs
@@ -1,0 +1,55 @@
+// A basic example of reading the current reserve interest rate, note/token exchange rate, and other
+// important information from the chain.
+
+// To get the most up-to-date information, always send a refresh and accrue ix (or CPI) just prior
+// to fetching this information. In this example, we don't care if the cache is stale.
+
+use crate::state::{
+    get_market_from_bytes, get_reserve_from_bytes, utilization_rate, Market, MarketReserves,
+    Reserve, ReserveInfo,
+};
+use anchor_lang::prelude::*;
+
+#[derive(Accounts)]
+pub struct GetCurrentInterest<'info> {
+    /// The market that the reserve is under
+    /// CHECK: no checks
+    #[account()]
+    pub market: AccountInfo<'info>,
+    /// A reserve where we want to see the current supply interest rate
+    /// CHECK: no checks
+    #[account()]
+    pub reserve: AccountInfo<'info>,
+}
+
+pub fn handler(ctx: Context<GetCurrentInterest>) -> Result<()> {
+    // Markets, reserves, and obligations are all Plain Old Data (POD), so you can read them from bytes!
+    // Don't forget to remove the 8-byte anchor discriminator...
+    let market_data = &ctx.accounts.market.try_borrow_data()?[..][8..];
+    let market: &Market = get_market_from_bytes(market_data);
+    let reserve_data = &ctx.accounts.reserve.try_borrow_data()?[..][8..];
+    let reserve: &Reserve = get_reserve_from_bytes(reserve_data);
+
+    let market_reserves: &MarketReserves = market.reserves();
+    let _reserve_info: &ReserveInfo = market_reserves.get(reserve.index);
+
+    let vault_total = reserve.total_deposits();
+    let _deposit_note_mint_supply = reserve.total_deposit_notes();
+    let _loan_note_mint_supply = reserve.total_loan_notes();
+
+    let outstanding_debt = reserve.unwrap_outstanding_debt_unsafe();
+    // For the most up-to-date information, run accrue_interest on the reserve first, then use:
+    // let outstanding_debt = reserve.unwrap_outstanding_debt();
+
+    // rates are stored in Number format, which is 10^15 decimals.
+    let utilization_rate = utilization_rate(*outstanding_debt, vault_total);
+    let interest_rate = reserve.interest_rate(*outstanding_debt, vault_total);
+
+    msg!(
+        "The utilization rate is {:?} and interest rate is: {:?}",
+        interest_rate,
+        utilization_rate
+    );
+
+    Ok(())
+}

--- a/programs/psylend-cpi/src/combinations/mod.rs
+++ b/programs/psylend-cpi/src/combinations/mod.rs
@@ -1,5 +1,7 @@
 pub mod accrue_deposit_token;
 pub mod accrue_withdraw_token;
+pub mod get_current_interest;
 
 pub use accrue_deposit_token::*;
 pub use accrue_withdraw_token::*;
+pub use get_current_interest::*;

--- a/programs/psylend-cpi/src/lib.rs
+++ b/programs/psylend-cpi/src/lib.rs
@@ -1,13 +1,15 @@
 use anchor_lang::prelude::*;
 
-declare_id!("BVr85VrQhRJAixhUt68bmodrvzv5nQXdUMbuihRWqNGb");
+declare_id!("2BUrizpXHXA43qJxnzRBGpwemtHKVqB3JE3G63NKHbzz");
 
 pub mod combinations;
 pub mod constants;
 pub mod instructions;
+pub mod state;
 pub mod utils;
 use combinations::*;
 use instructions::*;
+//use state::*;
 
 #[program]
 pub mod psylend_cpi {
@@ -120,6 +122,11 @@ pub mod psylend_cpi {
     ) -> Result<()> {
         combinations::accrue_withdraw_token::handler(ctx, amount)
     }
+
+    pub fn get_current_interest(ctx: Context<GetCurrentInterest>) -> Result<()> {
+        combinations::get_current_interest::handler(ctx)
+    }
+    
 
     // This ix is quite large, the program may not have space for it, or you may need to Box Accounts.
     // pub fn liquidate_cpi(

--- a/programs/psylend-cpi/src/state/cache.rs
+++ b/programs/psylend-cpi/src/state/cache.rs
@@ -1,0 +1,148 @@
+// Various PsyLend structs use a cache to store data on-chain. The cache is valid for some TTL,
+// expressed in slots, which varies by the data being stored.
+use bytemuck::{Pod, Zeroable};
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct Cache<T, const TTL: u64> {
+    /// The value being cached
+    value: T,
+
+    /// The last slot that this information was updated in
+    last_updated: u64,
+
+    /// Whether the value has been manually invalidated
+    invalidated: u8,
+
+    _reserved: [u8; 7],
+}
+
+// Since the `Cache` type uses generic parameters we can't use the derive macros
+// which help with some validation. The fields used are all pod-safe types, so
+// a `Cache` should also be pod-safe if the value stored within it is.
+unsafe impl<T, const TTL: u64> Pod for Cache<T, TTL> where T: Pod {}
+unsafe impl<T, const TTL: u64> Zeroable for Cache<T, TTL> where T: Zeroable {}
+
+/// Store calculated values that can be manually invalidated or expire after some number of slots
+/// Methods expect a "current_slot" argument which should indicate which slot the calculation is
+/// relevant for. This is usually the actual current slot but may be an older slot if the value is
+/// used or calculated for a previous slot, for example a partial refresh of the reserve.
+impl<T, const TTL: u64> Cache<T, TTL> {
+    pub fn new(value: T, current_slot: u64) -> Self {
+        Self {
+            value,
+            invalidated: 0,
+            last_updated: current_slot,
+            _reserved: [0; 7],
+        }
+    }
+
+    pub fn validate_fresh(&self, current_slot: u64) -> Result<(), CacheInvalidError> {
+        if current_slot < self.last_updated {
+            return Err(CacheInvalidError::TooNew {
+                msg: self.time_msg(current_slot),
+            });
+        }
+        if current_slot - self.last_updated > TTL {
+            return Err(CacheInvalidError::Expired {
+                msg: self.time_msg(current_slot),
+            });
+        }
+        if self.invalidated != 0 {
+            return Err(CacheInvalidError::Invalidated);
+        }
+        Ok(())
+    }
+
+    fn time_msg(&self, current_slot: u64) -> String {
+        format!(
+            "last_updated = {}, time_to_live = {}, current_slot = {}",
+            self.last_updated, TTL, current_slot
+        )
+    }
+
+    /// If the cache is neither expired nor marked invalid, return the value,
+    /// otherwise return an error indicating why it is stale
+    pub fn try_get(&self, current_slot: u64) -> Result<&T, CacheInvalidError> {
+        self.validate_fresh(current_slot)?;
+        Ok(&self.value)
+    }
+
+    /// If the cache is neither expired nor marked invalid, return the value mutably,
+    /// otherwise return an error indicating why it is stale
+    pub fn try_get_mut(&mut self, current_slot: u64) -> Result<&mut T, CacheInvalidError> {
+        self.validate_fresh(current_slot)?;
+        Ok(&mut self.value)
+    }
+
+    /// If the cache is neither expired nor marked invalid, return the value,
+    /// otherwise panic with an error message describing the item and why it is stale
+    pub fn expect(&self, current_slot: u64, description: &str) -> &T {
+        self.try_get(current_slot).expect(description)
+    }
+
+    /// If the cache is neither expired nor marked invalid, return the value mutably,
+    /// otherwise panic with an error message describing the item and why it is stale
+    pub fn expect_mut(&mut self, current_slot: u64, description: &str) -> &mut T {
+        self.try_get_mut(current_slot).expect(description)
+    }
+
+    /// Returns the current value, regardless of whether or not it is stale
+    pub fn get_stale(&self) -> &T {
+        &self.value
+    }
+
+    /// Returns the current value mutably, regardless of whether or not it is stale.
+    pub fn get_stale_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+
+    /// Replace the current value and reset the state to the current slot
+    pub fn refresh_as(&mut self, value: T, current_slot: u64) {
+        self.value = value;
+        self.invalidated = 0;
+        self.last_updated = current_slot;
+    }
+
+    /// Marks the data as stale
+    pub fn invalidate(&mut self) {
+        self.invalidated = 1;
+    }
+
+    /// Returns the slot when this data was last updated
+    pub fn last_updated(&self) -> u64 {
+        self.last_updated
+    }
+
+    // TODO this is identical to `refresh_to` and the comment is incorrect (it is mutating)
+    /// Updates the cache to be valid and at current_slot without mutating the value.
+    pub fn refresh(&mut self, current_slot: u64) {
+        self.invalidated = 0;
+        self.last_updated = current_slot;
+    }
+
+    /// Updates the cache to be valid and increments the last updated slot
+    pub fn refresh_additional(&mut self, additional_slots: u64) {
+        self.invalidated = 0;
+        self.last_updated += additional_slots;
+    }
+
+    /// Updates the cache to be valid and sets the last updated slot
+    pub fn refresh_to(&mut self, current_slot: u64) {
+        self.invalidated = 0;
+        self.last_updated = current_slot;
+    }
+}
+
+#[derive(Debug)]
+pub enum CacheInvalidError {
+    /// The cache is too old to use for the current slot.
+    Expired { msg: String },
+
+    /// A calculation was attempted for a slot that is too old to use the cache,
+    /// since the cache was created more recently than the relevant slot.
+    TooNew { msg: String },
+
+    /// The cache has been manually invalidated and may no longer be used.
+    Invalidated,
+}

--- a/programs/psylend-cpi/src/state/constants.rs
+++ b/programs/psylend-cpi/src/state/constants.rs
@@ -1,0 +1,3 @@
+/// How long NOTE and DATA cache are valid for (in slots).
+/// Note: The INFO cache is always valid for only 1 slot
+pub const CACHE_TTL_LONG: u64 = 100;

--- a/programs/psylend-cpi/src/state/market.rs
+++ b/programs/psylend-cpi/src/state/market.rs
@@ -1,0 +1,170 @@
+use anchor_lang::prelude::*;
+use bytemuck::{Pod, Zeroable};
+use psy_math::Number;
+
+use super::{Cache, FixedBuf, StoredPubkey, CACHE_TTL_LONG, ReserveIndex};
+
+/// Lending market account. All reserves and obligations must fall under a market. Some
+/// borrow-lending protocols prefer to use the terminology "pool"
+///
+/// Currently, there is a single primary market on mainnet (see constants.rs for the address)
+///
+/// Size = 16544 (plus 8 byte anchor discriminator)
+#[account(zero_copy)]
+pub struct Market {
+    pub version: u32,
+
+    /// UNUSED: The exponent used for quote prices
+    pub quote_exponent: i32,
+
+    /// The currency used for quote prices
+    pub quote_currency: [u8; 15],
+
+    /// The bump seed value for generating the authority address.
+    pub authority_bump_seed: [u8; 1],
+
+    /// The address used as the seed for generating the market authority
+    /// address. Typically this is the market account's own address.
+    pub authority_seed: Pubkey,
+
+    /// The account derived by the program, which has authority over all
+    /// assets in the market.
+    pub market_authority: Pubkey,
+
+    /// The account that has authority to make changes to the market
+    pub owner: Pubkey,
+
+    /// The mint for the token used by DEX to quote the value for reserve assets.
+    pub quote_token_mint: Pubkey,
+
+    /// Storage for flags that can be set on the market.
+    pub flags: u64,
+
+    /// State of rewards for the market.
+    pub market_reward_state: MarketRewardState,
+
+    /// Unused space before start of reserve list
+    _reserved: [u8; 352],
+
+    /// The storage for information on reserves in the market
+    reserves: [u8; 15872],
+}
+impl Market {
+    pub fn reserves(&self) -> &MarketReserves {
+        bytemuck::from_bytes(&self.reserves)
+    }
+}
+
+pub fn get_market_from_bytes(v: &[u8]) -> &Market{
+    bytemuck::from_bytes(v)
+}
+
+/// Defines various paramaters for rewards. Some values do not change after initialization, others
+/// can be updated between reward periods as needed.
+///
+/// Size = 160
+#[derive(Pod, Zeroable, Clone, Copy, AnchorDeserialize, AnchorSerialize)]
+#[repr(C)]
+pub struct MarketRewardState {
+    /// Pubkey of MarketReward account.
+    pub market_reward: Pubkey,
+
+    /// Timestamp at which first reward distribution period index begins.
+    /// The first reward period ends at `initial_reward_index_timestamp` + `distribution_period`
+    /// This should not change after initialization.
+    pub initial_reward_index_timestamp: i64,
+
+    /// Length of each distribution period in seconds.
+    /// This should not change after initialization.
+    pub distribution_period: u64,
+
+    /// Reward points allocated across whole market for each distribution period.
+    pub reward_points_per_period: u64,
+
+    /// Sum of reward multipliers across all Reserves in the market on each ObligationSide.
+    pub total_reward_multiplier: u64,
+
+    /// Time in seconds from start of period, after which withdrawal of rewards is allowed.
+    /// Typically this is earlier than the end of the period.
+    pub min_withdrawal_duration: u64,
+
+    /// Number of decimal places for cumulative reward units.
+    pub reward_unit_decimals: u8,
+
+    /// Unused space
+    pub _reserved0: [u8; 23],
+    pub _reserved1: [u8; 64],
+}
+
+/// All reserves under the market cache exchange rate information and various key parameters on the market
+/// Size = 15872
+#[derive(Pod, Zeroable, Clone, Copy)]
+#[repr(C)]
+pub struct MarketReserves {
+    /// Tracks the current prices of the tokens in reserve accounts
+    reserve_info: [ReserveInfo; 32],
+}
+impl MarketReserves {
+    pub fn get(&self, index: ReserveIndex) -> &ReserveInfo {
+        &self.reserve_info[index as usize]
+    }
+}
+
+/// Stores cached data for a reserve
+/// 
+/// Size = 496
+#[derive(Pod, Zeroable, Clone, Copy)]
+#[repr(C)]
+pub struct ReserveInfo {
+    /// The related reserve account
+    pub reserve: StoredPubkey,
+
+    /// Unused space
+    _reserved: FixedBuf<80>,
+
+    /// Cached values for the portion of the reserve info that is calculated dynamically
+    pub cached_info: Cache<CachedReserveInfo, 1>,
+
+    /// Cached values for reserve note exchange rates.
+    pub cached_note: Cache<CachedNoteInfo, { CACHE_TTL_LONG }>,
+}
+
+/// Stores information about the reserve's exchange rates
+/// 
+/// Size = 176
+#[derive(Pod, Zeroable, Clone, Copy, Debug)]
+#[repr(C)]
+pub struct CachedNoteInfo {
+    /// The value of the deposit note (unit: reserve tokens per note token)
+    pub deposit_note_exchange_rate: Number,
+
+    /// The value of the loan note (unit: reserve tokens per note token)
+    pub loan_note_exchange_rate: Number,
+
+    /// Unused space
+    _reserved: FixedBuf<128>,
+}
+
+/// Stores information about the reserve's config
+/// 
+/// Size = 176
+#[derive(Pod, Zeroable, Clone, Copy, Debug)]
+#[repr(C)]
+pub struct CachedReserveInfo {
+    /// The price of the asset being stored in the reserve account.
+    /// USD per smallest unit (1u64) of a token
+    pub price: Number,
+
+    /// The minimum allowable collateralization ratio for a loan on this reserve
+    pub min_collateral_ratio: Number,
+
+    /// The bonus awarded to liquidators when repaying a loan in exchange for a
+    /// collateral asset.
+    pub liquidation_bonus: u16,
+
+    /// Discount rate applied to tokens on this reserve (in bps)
+    pub discount_rate: u16,
+
+    /// Unused space
+    _reserved: FixedBuf<124>,
+}

--- a/programs/psylend-cpi/src/state/mod.rs
+++ b/programs/psylend-cpi/src/state/mod.rs
@@ -1,0 +1,13 @@
+pub mod market;
+pub mod reserve;
+pub mod obligation;
+pub mod utils;
+pub mod constants;
+pub mod cache;
+
+pub use market::*;
+pub use reserve::*;
+pub use obligation::*;
+pub use utils::*;
+pub use cache::*;
+pub use constants::*;

--- a/programs/psylend-cpi/src/state/obligation.rs
+++ b/programs/psylend-cpi/src/state/obligation.rs
@@ -1,0 +1,91 @@
+use anchor_lang::prelude::*;
+use psy_math::Number;
+use crate::state::FixedBuf;
+use bytemuck::{Pod, Zeroable};
+
+use super::{MAX_RESERVE_STATES, StoredPubkey};
+
+/// Describes the technical maximum number of supported positions. Loan/obligations arrays are 2560
+/// bytes and each position = 160 bytes. The max is 2560/160 = 16
+///
+/// PsyLend uses `MAX_ALLOWED_POSITIONS` to enforce a maximum below this value (to avoid
+/// limitations on transaction size using regular transactions)
+const _MAX_POSITIONS_TECHNICAL: usize = 16;
+
+/// If true, ixes that open a new position on the obligation (borrow, deposit collateral), will fail
+/// once the `MAX_ALLOWED_POSITIONS` limit is reached. If false, will allow positions to be opened
+/// indefinitely, though transaction size limits will eventually cause certain ixes to fail, as
+/// every reserve used on the obligation must be refreshed within the same slot.
+/// 
+/// With versioned transactions, obligations can now support more positions, up to the
+/// technical maximum. PsyLend may eventually disable this restriction.
+pub const _CAP_ALLOWED_POSITIONS: bool = true;
+
+/// Once this many collateral + loan positions are opened on an obligation, prevents borrowing or
+/// depositing on additional reserves. Only used if `CAP_ALLOWED_POSITIONS` is enabled.
+pub const _MAX_ALLOWED_POSITIONS: usize = 6;
+
+// 4 + 4 + 32 + 32 + 184 + 256 + 2560 + 2560 + (16 * 96)
+/// Size = 7168 (plus 8 byte anchor discriminator)
+/// Tracks information about a user's obligation to repay a borrowed position.
+#[account(zero_copy)]
+pub struct Obligation {
+    pub version: u32,
+
+    pub _reserved0: u32,
+
+    /// The market this obligation is a part of
+    pub market: Pubkey,
+
+    /// The address that owns the debt/assets as a part of this obligation
+    pub owner: Pubkey,
+
+    /// Unused space before start of collateral info
+    pub _reserved1: [u8; 184],
+
+    /// The storage for cached calculations
+    pub cached: [u8; 256],
+
+    /// The storage for the information on positions owed by this obligation
+    pub collateral: [u8; 2560],
+
+    /// The storage for the information on positions owed by this obligation
+    pub loans: [u8; 2560],
+
+    /// Each index corresponds to amount of reward units accrued during a
+    /// sequential distribution period, that is not yet claimed.
+    /// This value is denominated in reward_unit_decimals.
+    pub accrued_reward_units: [u128; MAX_RESERVE_STATES],
+}
+
+// Information about a single collateral or loan account registered with an obligation
+/// Size = 160 
+#[derive(Pod, Zeroable, Debug, Clone, Copy)]
+#[repr(C)]
+pub struct Position {
+    /// The token account holding the bank notes
+    pub account: StoredPubkey,
+
+    /// Non-authoritative number of bank notes placed in the account
+    pub amount: Number,
+
+    /// Timestamp when Position was last changed, used to determine time to start accruing rewards from.
+    /// Has to be initialized to System timestamp on Position creation.
+    pub last_updated: i64,
+
+    /// Cummulative sum of the reward points distributed per corresponding deposit or
+    /// loan note from start of the last_updated period to last_updated timestamp.
+    /// This value is denominated in reward_unit_decimals, for each unit of deposit or loan
+    /// note.
+    /// Has to be initialized to cummulative rewards units at time of Position creation.
+    pub cummulative_reward_units: u128,
+
+    pub side: u32,
+
+    /// The index of the reserve that this position's assets are from
+    pub reserve_index: ReserveIndex,
+
+    _reserved: FixedBuf<74>,
+}
+
+pub type ReserveIndex = u16;

--- a/programs/psylend-cpi/src/state/reserve.rs
+++ b/programs/psylend-cpi/src/state/reserve.rs
@@ -1,0 +1,317 @@
+use crate::state::FixedBuf;
+use anchor_lang::prelude::*;
+use bytemuck::{Pod, Zeroable};
+use psy_math::Number;
+
+use super::{Cache, CACHE_TTL_LONG, interpolate};
+
+/// There are this many reward states/periods before the reward functionality becomes inoperable.
+/// This is the number of indexes the array of states in the `market_rewards` struct can support.
+pub const MAX_RESERVE_STATES: usize = 96;
+
+// Size = 12
+#[repr(C)]
+#[derive(Pod, Zeroable, Clone, Copy, AnchorDeserialize, AnchorSerialize)]
+pub struct PsyFiVaultConfig {
+    pub vault_account: Pubkey,
+    pub collateral_token_decimals: u8,
+    pub _reserved1: [u8; 31],
+    pub _reserved2: [u8; 64],
+}
+
+/// All rates here are stored with a common denom of 10,000 (BPS_EXPONENT).
+/// For example, a 5% rate would be stored as .05 * 10,000 = 500
+/// 
+/// We have three interest rate regimes. The rate is described by a continuous,
+/// piecewise-linear function of the utilization rate:
+/// 1. zero to [utilization_rate_1]: borrow rate increases linearly from
+///     [borrow_rate_0] to [borrow_rate_1].
+/// 2. [utilization_rate_1] to [utilization_rate_2]: borrow rate increases linearly
+///     from [borrow_rate_1] to [borrow_rate_2].
+/// 3. [utilization_rate_2] to one: borrow rate increases linearly from
+///     [borrow_rate_2] to [borrow_rate_3].
+///
+/// Interest rates are nominal annual amounts, compounded continuously with
+/// a day-count convention of actual-over-365. The accrual period is determined
+/// by counting slots, and comparing against the number of slots per year.
+/// Size = 64
+#[repr(C)]
+#[derive(Pod, Zeroable, Clone, Copy, AnchorDeserialize, AnchorSerialize)]
+pub struct ReserveConfig {
+    /// The utilization rate at which we switch from the first to second regime.
+    pub utilization_rate_1: u16,
+
+    /// The utilization rate at which we switch from the second to third regime.
+    pub utilization_rate_2: u16,
+
+    /// The lowest borrow rate in the first regime. Essentially the minimum
+    /// borrow rate possible for the reserve.
+    pub borrow_rate_0: u16,
+
+    /// The borrow rate at the transition point from the first to second regime.
+    pub borrow_rate_1: u16,
+
+    /// The borrow rate at the transition point from the second to thirs regime.
+    pub borrow_rate_2: u16,
+
+    /// The highest borrow rate in the third regime. Essentially the maximum
+    /// borrow rate possible for the reserve.
+    pub borrow_rate_3: u16,
+
+    /// The minimum allowable collateralization ratio for an obligation
+    pub min_collateral_ratio: u16,
+
+    /// The amount given as a bonus to a liquidator
+    pub liquidation_premium: u16,
+
+    /// The threshold at which to collect the fees accumulated from interest into
+    /// real deposit notes.
+    pub manage_fee_collection_threshold: u64,
+
+    /// The fee rate applied to the interest payments collected
+    pub manage_fee_rate: u16,
+
+    /// The fee rate applied as interest owed on new loans
+    pub loan_origination_fee: u16,
+
+    /// unused
+    pub _reserved0: u16,
+
+    /// Represented as a percentage of the Price
+    /// confidence values above this will not be accepted
+    pub confidence_threshold: u16,
+
+    /// The maximum token amount to allow in a single DEX trade when
+    /// liquidating assetr from this reserve as collateral.
+    pub liquidation_dex_trade_max: u64,
+
+    /// Multiplier that determines the fraction of reward points (by dividing over
+    /// sum of all multiplier for the market) allocated for deposit notes.
+    pub deposit_reward_multiplier: u8,
+
+    /// Multiplier that determines the fraction of reward points (by dividing over
+    /// sum of all multiplier for the market) allocated for loan notes.
+    pub borrow_reward_multiplier: u8,
+
+    pub _reserved1: [u8; 22],
+}
+
+/// A reserve tracks a single asset for depositing and/or lending, under a single market.
+///
+/// Size = 5184 (plus 8 byte anchor discriminator)
+#[account(zero_copy)]
+pub struct Reserve {
+    pub version: u16,
+
+    /// The unique id for this reserve within the market.
+    /// Note: Should correspond to index of the `reserve_info` Vec on the market
+    pub index: u16,
+
+    /// The base 10 decimals used for token values
+    /// Note: Typically stored as a negative to reflect the Pyth value, but the absolute value is
+    /// used everywhere, so a positive number of equal magnitude can be used.
+    pub exponent: i32,
+
+    /// The market this reserve is a part of.
+    pub market: Pubkey,
+
+    /// The account where a Pyth oracle keeps the updated price of the token.
+    pub pyth_oracle_price: Pubkey,
+
+    /// The account where a Pyth oracle keeps metadata about the token.
+    pub pyth_oracle_product: Pubkey,
+
+    /// The mint for the token being held in this reserve
+    pub token_mint: Pubkey,
+
+    /// The mint for this reserve's deposit notes. Uses `token_mint` decimals.
+    pub deposit_note_mint: Pubkey,
+
+    /// The mint for this reserve's loan notes. Uses `token_mint` decimals.
+    pub loan_note_mint: Pubkey,
+
+    /// The account with custody over the reserve's tokens.
+    pub vault: Pubkey,
+
+    /// The account with custody of the notes generated from collected fees
+    pub fee_note_vault: Pubkey,
+
+    /// The account for storing quote tokens during a swap
+    pub dex_swap_tokens: Pubkey,
+
+    /// The account used for trading with the DEX
+    pub dex_open_orders: Pubkey,
+
+    /// The DEX market account that this reserve can trade in
+    pub dex_market: Pubkey,
+
+    pub _reserved0: [u8; 408],
+
+    pub config: ReserveConfig,
+
+    pub psyfi_vault_config: PsyFiVaultConfig,
+
+    /// Discount rate for the token this reserve uses, updated from the common discounts account
+    pub discount_rate: u16,
+
+    /// Current version of the discount rate. If lower than the version in the discounts account,
+    /// should be updated.
+    pub discount_rate_version: u16,
+
+    /// Indicates if the reserve has halted borrows, repays, or deposits:
+    ///
+    /// 0 (0b00000000) = nothing halted,
+    /// 1 (0b00000001) = deposits halted,
+    /// 2 (0b00000010) = borrows halted,
+    /// 4 (0b00000100) = repays halted,
+    /// 8 (0b00001000) = withdraws halted
+    ///
+    /// Allows addition or bitwise AND to combine multiple states:
+    /// (e.g., 4 + 2 = 6 (0b00000110) = borrows and repays halted, others allowed)
+    pub halt_state: u8,
+
+    _reserved1: [u8; 123],
+
+    // Define a u128 array here so struct aligns as 16 bytes for fields in ReserveState.
+    _reserved2: [u128; 32],
+
+    state: [u8; 3584],
+}
+
+pub fn get_reserve_from_bytes(v: &[u8]) -> &Reserve{
+    bytemuck::from_bytes(v)
+}
+
+impl Reserve {
+    fn state(&self) -> &Cache<ReserveState, { CACHE_TTL_LONG }> {
+        bytemuck::from_bytes(&self.state)
+    }
+    /// Get state, fail if expired. Accrue first, or this will fail
+    fn unwrap_state(&self, current_slot: u64) -> &ReserveState {
+        self.state()
+            .expect(current_slot, "Reserve needs to be refreshed")
+    }
+    /// Get state regardless of age. State may be any arbitrary number of slots old.
+    fn state_stale(&self) -> &ReserveState {
+        self.state().get_stale()
+    }
+
+    // The following values are always safe to extract from stale state, because any
+    // withdraw/deposit/borrow requires an accrue already.
+    pub fn total_deposits(&self) -> u64 {
+        self.state_stale().total_deposits
+    }
+    pub fn total_deposit_notes(&self) -> u64 {
+        self.state_stale().total_deposit_notes
+    }
+    pub fn total_loan_notes(&self) -> u64 {
+        self.state_stale().total_loan_notes
+    }
+    pub fn accrued_until(&self) -> i64 {
+        self.state_stale().accrued_until
+    }
+
+    /// Example to see actual current oustanding debt, which may update over time due to interest
+    pub fn unwrap_outstanding_debt(&self, current_slot: u64) -> &Number {
+        &self.unwrap_state(current_slot).outstanding_debt
+    }
+    /// For more approximate interest calculations, may be inaccurate unless accrue has occured recently.
+    pub fn unwrap_outstanding_debt_unsafe(&self) -> &Number {
+        &self.state_stale().outstanding_debt
+    }
+
+    /// Get the current interest rate for this reserve
+    pub fn interest_rate(&self, outstanding_debt: Number, vault_total: u64) -> Number {
+        let borrow_1 = Number::from_bps(self.config.borrow_rate_1);
+
+        // Catch the edge case of empty reserve
+        if vault_total == 0 && outstanding_debt == Number::ZERO {
+            return borrow_1;
+        }
+
+        let util_rate = utilization_rate(outstanding_debt, vault_total);
+
+        let util_1 = Number::from_bps(self.config.utilization_rate_1);
+
+        if util_rate <= util_1 {
+            // First regime
+            let borrow_0 = Number::from_bps(self.config.borrow_rate_0);
+
+            return interpolate(util_rate, Number::ZERO, util_1, borrow_0, borrow_1);
+        }
+
+        let util_2 = Number::from_bps(self.config.utilization_rate_2);
+        let borrow_2 = Number::from_bps(self.config.borrow_rate_2);
+
+        if util_rate <= util_2 {
+            // Second regime
+            let borrow_1 = Number::from_bps(self.config.borrow_rate_1);
+
+            return interpolate(util_rate, util_1, util_2, borrow_1, borrow_2);
+        }
+
+        let borrow_3 = Number::from_bps(self.config.borrow_rate_3);
+
+        if util_rate < Number::ONE {
+            // Third regime
+            return interpolate(util_rate, util_2, Number::ONE, borrow_2, borrow_3);
+        }
+
+        // Maximum interest
+        borrow_3
+    }
+}
+
+/// Get the current utilization rate (borrowed / deposited)
+pub fn utilization_rate(outstanding_debt: Number, vault_total: u64) -> Number {
+    outstanding_debt / (outstanding_debt + Number::from(vault_total))
+}
+
+/// Information about a reserve's current assets and outstanding deposit/loan notes and reward units.
+///
+/// Notes:
+/// To get the total amount of tokens under the reserve's control, use:
+/// (`total_deposits` + `outstanding_debt` - `uncollected_fees`)
+///
+/// For total deposit/loan notes in circulation: `total_deposit_notes`, `total_loan_notes`
+/// Size = 3568
+#[derive(Pod, Zeroable, Clone, Copy)]
+#[repr(C)]
+struct ReserveState {
+    accrued_until: i64,
+
+    /// Amount of deposited tokens loaned out to borrowers, plus amount of tokens charged
+    /// in fees (in U192 Number, in token.)
+    ///
+    /// Storage format example: debt is 5.927 token, with 8 token decimals
+    /// `5.927 * 10 ^ 8 * 10 ^ 15 = 592,700,000,000,000,000,000,000`
+    outstanding_debt: Number,
+
+    /// Amount of fees collected (in U192 Number, in token). `Outstanding debt` includes
+    /// this amount.
+    ///
+    /// Storage format example: fees are 5.927 token, with 8 token decimals
+    /// `5.927 * 10 ^ 8 * 10 ^ 15 = 592,700,000,000,000,000,000,000`
+    uncollected_fees: Number,
+
+    /// Amount of deposited tokens that is not borrowed (in token)
+    total_deposits: u64,
+
+    /// Amount of deposit notes issued and in circulation (i.e., matches mint's supply)
+    total_deposit_notes: u64,
+
+    /// Amount of loan notes issued and in circulation (i.e., matches mint's supply)
+    total_loan_notes: u64,
+
+    /// Each index corresponds to cummulative sum of the reward points distributed
+    /// per deposit note for the distribution period. This value is denominated in
+    /// reward_unit_decimals.
+    cummulative_deposit_reward_units: [u128; MAX_RESERVE_STATES],
+
+    /// Each index corresponds to cummulative sum of the reward points distributed
+    /// distributed per loan note for the distribution period. This value is denominated in
+    /// reward_unit_decimals.
+    cummulative_loan_reward_units: [u128; MAX_RESERVE_STATES],
+
+    _reserved: FixedBuf<416>,
+}

--- a/programs/psylend-cpi/src/state/utils.rs
+++ b/programs/psylend-cpi/src/state/utils.rs
@@ -1,0 +1,56 @@
+use anchor_lang::prelude::Pubkey;
+use bytemuck::{Pod, Zeroable};
+use psy_math::Number;
+
+/// A fixed-size byte array
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct FixedBuf<const SIZE: usize> {
+    data: [u8; SIZE],
+}
+unsafe impl<const SIZE: usize> Pod for FixedBuf<SIZE> {}
+unsafe impl<const SIZE: usize> Zeroable for FixedBuf<SIZE> {}
+impl<const SIZE: usize> std::fmt::Debug for FixedBuf<SIZE> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FixedBuf<{}>", SIZE)
+    }
+}
+
+/// Workaround for the fact that `Pubkey` doesn't implement the
+/// `Pod` trait (even though it meets the requirements), and there
+/// isn't really a way for us to extend the original type, so we wrap
+/// it in a new one.
+#[derive(Eq, PartialEq, Clone, Copy)]
+#[repr(transparent)]
+pub struct StoredPubkey(Pubkey);
+
+impl AsRef<Pubkey> for StoredPubkey {
+    fn as_ref(&self) -> &Pubkey {
+        &self.0
+    }
+}
+impl From<StoredPubkey> for Pubkey {
+    fn from(key: StoredPubkey) -> Self {
+        key.0
+    }
+}
+impl From<Pubkey> for StoredPubkey {
+    fn from(key: Pubkey) -> Self {
+        Self(key)
+    }
+}
+impl std::fmt::Debug for StoredPubkey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        (&self.0 as &dyn std::fmt::Display).fmt(f)
+    }
+}
+unsafe impl Pod for StoredPubkey {}
+unsafe impl Zeroable for StoredPubkey {}
+
+/// Linear interpolation between (x0, y0) and (x1, y1).
+pub fn interpolate(x: Number, x0: Number, x1: Number, y0: Number, y1: Number) -> Number {
+    assert!(x >= x0);
+    assert!(x <= x1);
+
+    y0 + ((x - x0) * (y1 - y0)) / (x1 - x0)
+}

--- a/tests/basic-integrator.ts
+++ b/tests/basic-integrator.ts
@@ -157,6 +157,25 @@ describe("Generic supply-side yield aggregator example", () => {
     }
   });
 
+  it("Read the current interest rate on some reserve", async () => {
+    const ix = await program.methods
+      .getCurrentInterest()
+      .accounts({
+        market: marketKey,
+        reserve: usdcReserveKey,
+      })
+      .instruction();
+
+    try {
+      await provider.sendAndConfirm(new Transaction().add(ix));
+    } catch (err) {
+      console.log(err);
+      throw err;
+    }
+    // Check the program log to see the message.
+
+  })
+
   it("Creates external USDC deposit account (not owned by PsyLend)", async () => {
     // Deposit notes will be go into this account after a deposit
     usdcDepositAccountKey = getAssociatedTokenAddressSync(


### PR DESCRIPTION
Closes #3 

Adds market, reserve, obligation, and all applicable caches. Adds an instruction and test that fetches the interest rate and other potentially useful data for some reserve on PsyLend.