### PR TITLE
[WIP] Example public instruction getter

### DIFF
--- a/programs/psylend-cpi/src/instructions/borrow.rs
+++ b/programs/psylend-cpi/src/instructions/borrow.rs
@@ -60,7 +60,7 @@ pub struct Borrow<'info> {
 
 pub fn handler(ctx: Context<Borrow>, bump: u8, amount: Amount) -> Result<()> {
     let psylend_program_id: Pubkey = Pubkey::from_str(PSYLEND_PROGRAM_KEY).unwrap();
-    let instruction: Instruction = get_cpi_instruction(&ctx, psylend_program_id, bump, amount)?;
+    let instruction: Instruction = borrow_cpi_instruction(&ctx, psylend_program_id, bump, amount)?;
     let account_infos = [
         ctx.accounts.market.to_account_info(),
         ctx.accounts.market_authority.to_account_info(),
@@ -79,7 +79,7 @@ pub fn handler(ctx: Context<Borrow>, bump: u8, amount: Amount) -> Result<()> {
     Ok(())
 }
 
-fn get_cpi_instruction(
+pub fn borrow_cpi_instruction(
     ctx: &Context<Borrow>,
     program_id: Pubkey,
     bump: u8,
@@ -99,22 +99,49 @@ fn get_cpi_instruction(
             AccountMeta::new(ctx.accounts.receiver_account.key(), false),
             AccountMeta::new_readonly(ctx.accounts.token_program.key(), false),
         ],
-        data: get_ix_data(bump, amount),
+        data: borrow_ix_data(bump, amount),
     };
     Ok(instruction)
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
-struct CpiArgs {
+pub struct BorrowCpiArgs {
     bump: u8,
     amount: Amount,
 }
 
-fn get_ix_data(bump: u8, amount: Amount) -> Vec<u8> {
+pub fn borrow_ix_data(bump: u8, amount: Amount) -> Vec<u8> {
     let hash = get_function_hash("global", "borrow");
     let mut buf: Vec<u8> = vec![];
     buf.extend_from_slice(&hash);
-    let args = CpiArgs { bump, amount };
+    let args = BorrowCpiArgs { bump, amount };
     args.serialize(&mut buf).unwrap();
     buf
+}
+
+/// Build a CPI instruction. Accounts must be in the same order as Context
+/// `Borrow`
+pub fn borrow_cpi_ix(
+    account_infos: &[AccountInfo; 11],
+    program_id: Pubkey,
+    amount: Amount,
+    bump: u8,
+) -> Result<Instruction> {
+    let instruction = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(account_infos[0].key(), false),
+            AccountMeta::new_readonly(account_infos[1].key(), false),
+            AccountMeta::new(account_infos[2].key(), false),
+            AccountMeta::new(account_infos[3].key(), false),
+            AccountMeta::new(account_infos[4].key(), false),
+            AccountMeta::new(account_infos[5].key(), false),
+            AccountMeta::new_readonly(account_infos[6].key(), true),
+            AccountMeta::new(account_infos[7].key(), false),
+            AccountMeta::new(account_infos[8].key(), false),
+            AccountMeta::new_readonly(account_infos[9].key(), false),
+        ],
+        data: borrow_ix_data(bump, amount),
+    };
+    Ok(instruction)
 }

--- a/programs/psylend-cpi/src/instructions/close_deposit_account.rs
+++ b/programs/psylend-cpi/src/instructions/close_deposit_account.rs
@@ -56,7 +56,7 @@ pub struct CloseDepositAccount<'info> {
 
 pub fn handler(ctx: Context<CloseDepositAccount>) -> Result<()> {
     let psylend_program_id: Pubkey = Pubkey::from_str(PSYLEND_PROGRAM_KEY).unwrap();
-    let instruction: Instruction = get_cpi_instruction(&ctx, psylend_program_id)?;
+    let instruction: Instruction = close_deposit_cpi_instruction(&ctx, psylend_program_id)?;
     let account_infos = [
         ctx.accounts.market.to_account_info(),
         ctx.accounts.market_authority.to_account_info(),
@@ -74,7 +74,7 @@ pub fn handler(ctx: Context<CloseDepositAccount>) -> Result<()> {
     Ok(())
 }
 
-fn get_cpi_instruction(
+pub fn close_deposit_cpi_instruction(
     ctx: &Context<CloseDepositAccount>,
     program_id: Pubkey,
 ) -> Result<Instruction> {
@@ -90,6 +90,30 @@ fn get_cpi_instruction(
             AccountMeta::new(ctx.accounts.deposit_account.key(), false),
             AccountMeta::new(ctx.accounts.receiver_account.key(), false),
             AccountMeta::new_readonly(ctx.accounts.token_program.key(), false),
+        ],
+        data: get_function_hash("global", "close_deposit_account").to_vec(),
+    };
+    Ok(instruction)
+}
+
+/// Build a CPI instruction. Accounts must be in the same order as Context
+/// `CloseDepositAccount`
+pub fn close_deposit_cpi_ix(
+    account_infos: &[AccountInfo; 10],
+    program_id: Pubkey,
+) -> Result<Instruction> {
+    let instruction = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(account_infos[0].key(), false),
+            AccountMeta::new_readonly(account_infos[1].key(), false),
+            AccountMeta::new(account_infos[2].key(), false),
+            AccountMeta::new(account_infos[3].key(), false),
+            AccountMeta::new(account_infos[4].key(), false),
+            AccountMeta::new(account_infos[5].key(), true),
+            AccountMeta::new(account_infos[6].key(), false),
+            AccountMeta::new(account_infos[7].key(), false),
+            AccountMeta::new_readonly(account_infos[8].key(), false),
         ],
         data: get_function_hash("global", "close_deposit_account").to_vec(),
     };

--- a/programs/psylend-cpi/src/instructions/close_obligation.rs
+++ b/programs/psylend-cpi/src/instructions/close_obligation.rs
@@ -34,7 +34,7 @@ pub struct CloseObligation<'info> {
 
 pub fn handler(ctx: Context<CloseObligation>) -> Result<()> {
     let psylend_program_id: Pubkey = Pubkey::from_str(PSYLEND_PROGRAM_KEY).unwrap();
-    let instruction: Instruction = get_cpi_instruction(&ctx, psylend_program_id)?;
+    let instruction: Instruction = close_obligation_cpi_instruction(&ctx, psylend_program_id)?;
     let account_infos = [
         ctx.accounts.market.to_account_info(),
         ctx.accounts.market_authority.to_account_info(),
@@ -47,7 +47,7 @@ pub fn handler(ctx: Context<CloseObligation>) -> Result<()> {
     Ok(())
 }
 
-fn get_cpi_instruction(
+pub fn close_obligation_cpi_instruction(
     ctx: &Context<CloseObligation>,
     program_id: Pubkey,
 ) -> Result<Instruction> {
@@ -58,6 +58,25 @@ fn get_cpi_instruction(
             AccountMeta::new_readonly(ctx.accounts.market_authority.key(), false),
             AccountMeta::new(ctx.accounts.owner.key(), true),
             AccountMeta::new(ctx.accounts.obligation.key(), false),
+        ],
+        data: get_function_hash("global", "close_obligation").to_vec(),
+    };
+    Ok(instruction)
+}
+
+/// Build a CPI instruction. Accounts must be in the same order as Context
+/// `CloseObligation`
+pub fn close_obligation_cpi_ix(
+    account_infos: &[AccountInfo; 5],
+    program_id: Pubkey,
+) -> Result<Instruction> {
+    let instruction = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(  account_infos[0].key(), false),
+            AccountMeta::new_readonly(  account_infos[1].key(), false),
+            AccountMeta::new(           account_infos[2].key(), true),
+            AccountMeta::new(           account_infos[3].key(), false),
         ],
         data: get_function_hash("global", "close_obligation").to_vec(),
     };

--- a/programs/psylend-cpi/src/instructions/deposit.rs
+++ b/programs/psylend-cpi/src/instructions/deposit.rs
@@ -55,7 +55,7 @@ pub struct Deposit<'info> {
 
 pub fn handler(ctx: Context<Deposit>, bump: u8, amount: Amount) -> Result<()> {
     let psylend_program_id: Pubkey = Pubkey::from_str(PSYLEND_PROGRAM_KEY).unwrap();
-    let instruction: Instruction = deposit_instruction(&ctx, psylend_program_id, bump, amount)?;
+    let instruction: Instruction = deposit_cpi_instruction(&ctx, psylend_program_id, bump, amount)?;
     let account_infos = [
         ctx.accounts.market.to_account_info(),
         ctx.accounts.market_authority.to_account_info(),
@@ -73,7 +73,7 @@ pub fn handler(ctx: Context<Deposit>, bump: u8, amount: Amount) -> Result<()> {
     Ok(())
 }
 
-pub fn deposit_instruction(
+pub fn deposit_cpi_instruction(
     ctx: &Context<Deposit>,
     program_id: Pubkey,
     bump: u8,
@@ -92,7 +92,7 @@ pub fn deposit_instruction(
             AccountMeta::new(ctx.accounts.deposit_source.key(), false),
             AccountMeta::new_readonly(ctx.accounts.token_program.key(), false),
         ],
-        data: get_deposit_data(bump, amount),
+        data: deposit_ix_data(bump, amount),
     };
     Ok(instruction)
 }
@@ -100,14 +100,40 @@ pub fn deposit_instruction(
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct DepositCpiArgs {
     bump: u8,
-    amount: Amount
+    amount: Amount,
 }
 
-pub fn get_deposit_data(bump: u8, amount: Amount) -> Vec<u8> {
+pub fn deposit_ix_data(bump: u8, amount: Amount) -> Vec<u8> {
     let hash = get_function_hash("global", "deposit");
     let mut buf: Vec<u8> = vec![];
     buf.extend_from_slice(&hash);
     let args = DepositCpiArgs { bump, amount };
     args.serialize(&mut buf).unwrap();
     buf
+}
+
+/// Build a CPI instruction. Accounts must be in the same order as Context
+/// `Deposit`
+pub fn deposit_cpi_ix(
+    account_infos: &[AccountInfo; 10],
+    program_id: Pubkey,
+    amount: Amount,
+    bump: u8,
+) -> Result<Instruction> {
+    let instruction = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(account_infos[0].key(), false),
+            AccountMeta::new_readonly(account_infos[1].key(), false),
+            AccountMeta::new(account_infos[2].key(), false),
+            AccountMeta::new(account_infos[3].key(), false),
+            AccountMeta::new(account_infos[4].key(), false),
+            AccountMeta::new_readonly(account_infos[5].key(), true),
+            AccountMeta::new(account_infos[6].key(), false),
+            AccountMeta::new(account_infos[7].key(), false),
+            AccountMeta::new_readonly(account_infos[8].key(), false),
+        ],
+        data: deposit_ix_data(bump, amount),
+    };
+    Ok(instruction)
 }

--- a/programs/psylend-cpi/src/instructions/deposit.rs
+++ b/programs/psylend-cpi/src/instructions/deposit.rs
@@ -55,7 +55,7 @@ pub struct Deposit<'info> {
 
 pub fn handler(ctx: Context<Deposit>, bump: u8, amount: Amount) -> Result<()> {
     let psylend_program_id: Pubkey = Pubkey::from_str(PSYLEND_PROGRAM_KEY).unwrap();
-    let instruction: Instruction = get_cpi_instruction(&ctx, psylend_program_id, bump, amount)?;
+    let instruction: Instruction = deposit_instruction(&ctx, psylend_program_id, bump, amount)?;
     let account_infos = [
         ctx.accounts.market.to_account_info(),
         ctx.accounts.market_authority.to_account_info(),
@@ -73,7 +73,7 @@ pub fn handler(ctx: Context<Deposit>, bump: u8, amount: Amount) -> Result<()> {
     Ok(())
 }
 
-fn get_cpi_instruction(
+pub fn deposit_instruction(
     ctx: &Context<Deposit>,
     program_id: Pubkey,
     bump: u8,
@@ -92,22 +92,22 @@ fn get_cpi_instruction(
             AccountMeta::new(ctx.accounts.deposit_source.key(), false),
             AccountMeta::new_readonly(ctx.accounts.token_program.key(), false),
         ],
-        data: get_ix_data(bump, amount),
+        data: get_deposit_data(bump, amount),
     };
     Ok(instruction)
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
-struct CpiArgs {
+pub struct DepositCpiArgs {
     bump: u8,
     amount: Amount
 }
 
-fn get_ix_data(bump: u8, amount: Amount) -> Vec<u8> {
+pub fn get_deposit_data(bump: u8, amount: Amount) -> Vec<u8> {
     let hash = get_function_hash("global", "deposit");
     let mut buf: Vec<u8> = vec![];
     buf.extend_from_slice(&hash);
-    let args = CpiArgs { bump, amount };
+    let args = DepositCpiArgs { bump, amount };
     args.serialize(&mut buf).unwrap();
     buf
 }

--- a/programs/psylend-cpi/src/instructions/init_deposit_account.rs
+++ b/programs/psylend-cpi/src/instructions/init_deposit_account.rs
@@ -48,7 +48,7 @@ pub struct InitializeDepositAccount<'info> {
 
 pub fn handler(ctx: Context<InitializeDepositAccount>, bump: u8) -> Result<()> {
     let psylend_program_id: Pubkey = Pubkey::from_str(PSYLEND_PROGRAM_KEY).unwrap();
-    let instruction: Instruction = get_cpi_instruction(&ctx, psylend_program_id, bump)?;
+    let instruction: Instruction = init_deposit_cpi_instruction(&ctx, psylend_program_id, bump)?;
     let account_infos = [
         ctx.accounts.market.to_account_info(),
         ctx.accounts.market_authority.to_account_info(),
@@ -67,7 +67,7 @@ pub fn handler(ctx: Context<InitializeDepositAccount>, bump: u8) -> Result<()> {
     Ok(())
 }
 
-fn get_cpi_instruction(
+pub fn init_deposit_cpi_instruction(
     ctx: &Context<InitializeDepositAccount>,
     program_id: Pubkey,
     bump: u8,
@@ -85,21 +85,46 @@ fn get_cpi_instruction(
             AccountMeta::new_readonly(ctx.accounts.system_program.key(), false),
             AccountMeta::new_readonly(ctx.accounts.rent.key(), false),
         ],
-        data: get_ix_data(bump),
+        data: init_deposit_ix_data(bump),
     };
     Ok(instruction)
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
-struct CpiArgs {
+pub struct InitDepositCpiArgs {
     bump: u8,
 }
 
-fn get_ix_data(bump: u8) -> Vec<u8> {
+pub fn init_deposit_ix_data(bump: u8) -> Vec<u8> {
     let hash = get_function_hash("global", "init_deposit_account");
     let mut buf: Vec<u8> = vec![];
     buf.extend_from_slice(&hash);
-    let args = CpiArgs { bump };
+    let args = InitDepositCpiArgs { bump };
     args.serialize(&mut buf).unwrap();
     buf
+}
+
+/// Build a CPI instruction. Accounts must be in the same order as Context
+/// `InitializeDepositAccount`
+pub fn init_deposit_cpi_ix(
+    account_infos: &[AccountInfo; 10],
+    program_id: Pubkey,
+    bump: u8,
+) -> Result<Instruction> {
+    let instruction = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(account_infos[0].key(), false),
+            AccountMeta::new_readonly(account_infos[1].key(), false),
+            AccountMeta::new_readonly(account_infos[2].key(), false),
+            AccountMeta::new_readonly(account_infos[3].key(), false),
+            AccountMeta::new(account_infos[4].key(), true),
+            AccountMeta::new(account_infos[5].key(), false),
+            AccountMeta::new_readonly(account_infos[6].key(), false),
+            AccountMeta::new_readonly(account_infos[7].key(), false),
+            AccountMeta::new_readonly(account_infos[8].key(), false),
+        ],
+        data: init_deposit_ix_data(bump),
+    };
+    Ok(instruction)
 }

--- a/programs/psylend-cpi/src/instructions/refresh_psyfi_reserve.rs
+++ b/programs/psylend-cpi/src/instructions/refresh_psyfi_reserve.rs
@@ -35,16 +35,7 @@ pub struct RefreshPsyFiReserve<'info> {
 
 pub fn handler(ctx: Context<RefreshPsyFiReserve>) -> Result<()> {
     let program_id: Pubkey = Pubkey::from_str(PSYLEND_PROGRAM_KEY).unwrap();
-    let instruction = Instruction {
-        program_id,
-        accounts: vec![
-            AccountMeta::new(ctx.accounts.market.key(), false),
-            AccountMeta::new_readonly(ctx.accounts.reserve.key(), false),
-            AccountMeta::new_readonly(ctx.accounts.psyfi_vault_account.key(), false),
-            AccountMeta::new_readonly(ctx.accounts.pyth_oracle_price.key(), false),
-        ],
-        data: get_function_hash("global", "refresh_psyfi_reserve").to_vec(),
-    };
+    let instruction = refresh_psyfi_cpi_instruction(&ctx, program_id)?;
     let account_infos = [
         ctx.accounts.market.to_account_info(),
         ctx.accounts.reserve.to_account_info(),
@@ -55,4 +46,40 @@ pub fn handler(ctx: Context<RefreshPsyFiReserve>) -> Result<()> {
 
     invoke(&instruction, &account_infos)?;
     Ok(())
+}
+
+pub fn refresh_psyfi_cpi_instruction(
+    ctx: &Context<RefreshPsyFiReserve>,
+    program_id: Pubkey,
+) -> Result<Instruction> {
+    let instruction = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(ctx.accounts.market.key(), false),
+            AccountMeta::new_readonly(ctx.accounts.reserve.key(), false),
+            AccountMeta::new_readonly(ctx.accounts.psyfi_vault_account.key(), false),
+            AccountMeta::new_readonly(ctx.accounts.pyth_oracle_price.key(), false),
+        ],
+        data: get_function_hash("global", "refresh_psyfi_reserve").to_vec(),
+    };
+    Ok(instruction)
+}
+
+/// Build a CPI instruction. Accounts must be in the same order as Context
+/// `RefreshPsyFiReserve`
+pub fn refresh_psyfi_cpi_ix(
+    account_infos: &[AccountInfo; 5],
+    program_id: Pubkey,
+) -> Result<Instruction> {
+    let instruction = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(account_infos[0].key(), false),
+            AccountMeta::new_readonly(account_infos[1].key(), false),
+            AccountMeta::new_readonly(account_infos[2].key(), false),
+            AccountMeta::new_readonly(account_infos[3].key(), false),
+        ],
+        data: get_function_hash("global", "refresh_psyfi_reserve").to_vec(),
+    };
+    Ok(instruction)
 }

--- a/programs/psylend-cpi/src/instructions/refresh_reserve.rs
+++ b/programs/psylend-cpi/src/instructions/refresh_reserve.rs
@@ -30,15 +30,7 @@ pub struct RefreshReserve<'info> {
 
 pub fn handler(ctx: Context<RefreshReserve>) -> Result<()> {
     let program_id: Pubkey = Pubkey::from_str(PSYLEND_PROGRAM_KEY).unwrap();
-    let instruction = Instruction {
-        program_id,
-        accounts: vec![
-            AccountMeta::new(ctx.accounts.market.key(), false),
-            AccountMeta::new_readonly(ctx.accounts.reserve.key(), false),
-            AccountMeta::new_readonly(ctx.accounts.pyth_oracle_price.key(), false),
-        ],
-        data: get_function_hash("global", "refresh_reserve").to_vec(),
-    };
+    let instruction = refresh_cpi_instruction(&ctx, program_id)?;
     let account_infos = [
         ctx.accounts.market.to_account_info(),
         ctx.accounts.reserve.to_account_info(),
@@ -48,4 +40,38 @@ pub fn handler(ctx: Context<RefreshReserve>) -> Result<()> {
 
     invoke(&instruction, &account_infos)?;
     Ok(())
+}
+
+pub fn refresh_cpi_instruction(
+    ctx: &Context<RefreshReserve>,
+    program_id: Pubkey,
+) -> Result<Instruction> {
+    let instruction = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(ctx.accounts.market.key(), false),
+            AccountMeta::new_readonly(ctx.accounts.reserve.key(), false),
+            AccountMeta::new_readonly(ctx.accounts.pyth_oracle_price.key(), false),
+        ],
+        data: get_function_hash("global", "refresh_reserve").to_vec(),
+    };
+    Ok(instruction)
+}
+
+/// Build a CPI instruction. Accounts must be in the same order as Context
+/// `RefreshReserve`
+pub fn refresh_cpi_ix(
+    account_infos: &[AccountInfo; 4],
+    program_id: Pubkey,
+) -> Result<Instruction> {
+    let instruction = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(account_infos[0].key(), false),
+            AccountMeta::new_readonly(account_infos[1].key(), false),
+            AccountMeta::new_readonly(account_infos[2].key(), false),
+        ],
+        data: get_function_hash("global", "refresh_reserve").to_vec(),
+    };
+    Ok(instruction)
 }

--- a/programs/psylend-cpi/src/instructions/withdraw_collateral.rs
+++ b/programs/psylend-cpi/src/instructions/withdraw_collateral.rs
@@ -55,7 +55,7 @@ pub fn handler(
     amount: Amount,
 ) -> Result<()> {
     let psylend_program_id: Pubkey = Pubkey::from_str(PSYLEND_PROGRAM_KEY).unwrap();
-    let instruction: Instruction = get_cpi_instruction(
+    let instruction: Instruction = withdraw_collateral_cpi_instruction(
         &ctx,
         psylend_program_id,
         collateral_bump,
@@ -78,7 +78,7 @@ pub fn handler(
     Ok(())
 }
 
-fn get_cpi_instruction(
+pub fn withdraw_collateral_cpi_instruction(
     ctx: &Context<WithdrawCollateral>,
     program_id: Pubkey,
     collateral_bump: u8,
@@ -97,27 +97,57 @@ fn get_cpi_instruction(
             AccountMeta::new(ctx.accounts.collateral_account.key(), false),
             AccountMeta::new_readonly(ctx.accounts.token_program.key(), false),
         ],
-        data: get_ix_data(collateral_bump, deposit_bump, amount),
+        data: withdraw_collateral_ix_data(collateral_bump, deposit_bump, amount),
     };
     Ok(instruction)
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
-struct CpiArgs {
+pub struct WithdrawCollateralCpiArgs {
     collateral_bump: u8,
     deposit_bump: u8,
     amount: Amount,
 }
 
-fn get_ix_data(collateral_bump: u8, deposit_bump: u8, amount: Amount) -> Vec<u8> {
+pub fn withdraw_collateral_ix_data(
+    collateral_bump: u8,
+    deposit_bump: u8,
+    amount: Amount,
+) -> Vec<u8> {
     let hash = get_function_hash("global", "withdraw_collateral");
     let mut buf: Vec<u8> = vec![];
     buf.extend_from_slice(&hash);
-    let args = CpiArgs {
+    let args = WithdrawCollateralCpiArgs {
         collateral_bump,
         deposit_bump,
         amount,
     };
     args.serialize(&mut buf).unwrap();
     buf
+}
+
+/// Build a CPI instruction. Accounts must be in the same order as Context
+/// `WithdrawCollateral`
+pub fn withdraw_collateral_cpi_ix(
+    account_infos: &[AccountInfo; 9],
+    program_id: Pubkey,
+    amount: Amount,
+    collateral_bump: u8,
+    deposit_bump: u8,
+) -> Result<Instruction> {
+    let instruction = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(account_infos[0].key(), false),
+            AccountMeta::new_readonly(account_infos[1].key(), false),
+            AccountMeta::new_readonly(account_infos[2].key(), false),
+            AccountMeta::new(account_infos[3].key(), false),
+            AccountMeta::new_readonly(account_infos[4].key(), true),
+            AccountMeta::new(account_infos[5].key(), false),
+            AccountMeta::new(account_infos[6].key(), false),
+            AccountMeta::new_readonly(account_infos[7].key(), false),
+        ],
+        data: withdraw_collateral_ix_data(collateral_bump, deposit_bump, amount),
+    };
+    Ok(instruction)
 }

--- a/tests/psylend-cpi.ts
+++ b/tests/psylend-cpi.ts
@@ -1011,7 +1011,7 @@ describe("PsyLend CPI examples", () => {
     if (verbose) {
       const bal = await con.getBalance(wallet.publicKey);
       console.log("Test suite done.");
-      console.log("wallet final SOL balance: " + bal);
+      console.log("wallet final SOL balance: " + bal.toLocaleString());
     }
   });
 });


### PR DESCRIPTION
Closes #6 

@KaustubhShamshery - what do you think of this function layout: now you can call `deposit::deposit_instruction`, and if you just need the data you can call `deposit::get_deposit_data`

I am trying to decide between this and keeping all the functions with the same consistent name, e.g. `deposit::get_instruction`, `withdraw::get_instructions`, etc.